### PR TITLE
libc/time: Fix `mktime()` wrong behavior when time can not be represented

### DIFF
--- a/newlib/libc/time/mktime.c
+++ b/newlib/libc/time/mktime.c
@@ -191,6 +191,10 @@ mktime_utc (struct tm *tim_p, long *days_p)
   /* validate structure */
   validate_structure (tim_p);
 
+  /* check if year has valid value */  
+  if (tim_p->tm_year > 10000 || tim_p->tm_year < 0)
+      return (time_t) -1;
+    
   /* compute hours, minutes, seconds */
   tim += tim_p->tm_sec + (tim_p->tm_min * SECSPERMIN) +
     (tim_p->tm_hour * SECSPERHOUR);
@@ -203,9 +207,6 @@ mktime_utc (struct tm *tim_p, long *days_p)
 
   /* compute day of the year */
   tim_p->tm_yday = days;
-
-  if (tim_p->tm_year > 10000 || tim_p->tm_year < -10000)
-      return (time_t) -1;
 
   /* compute days in other years */
   if ((year = tim_p->tm_year) > 70)


### PR DESCRIPTION
Part 7.23.2.1 requires that, quoting,
```
The tm structure shall contain at least the following members,
in any order. The semantics of the members and their normal ranges are expressed in the
comments.
int tm_sec; // seconds after the minute — [0, 60]
int tm_min; // minutes after the hour — [0, 59]
int tm_hour; // hours since midnight — [0, 23]
int tm_mday; // day of the month — [1, 31]
int tm_mon; // months since January — [0, 11]
int tm_year; // years since 1900
int tm_wday; // days since Sunday — [0, 6]
int tm_yday; // days since January 1 — [0, 365]
int tm_isdst; // Daylight Saving Time flag
So the tm structure can only represent years after 1900 which can only be indicated by positive value.
```
Part 7.23.2.3 also described the limitations on input and output as follows:
quoting:
```
The original values of the tm_wday and tm_yday components of the structure are ignored, 
and the original values of the other components are not restricted to the ranges indicated above.

On successful completion, the values of the tm_wday and tm_yday components of the structure are set appropriately, and the other components are set to represent the specified calendar time, but with their values forced to the ranges indicated above; the final value of tm_mday is not set until tm_mon and tm_year are determined.
```
And accordingly the check on the year value in related code was changed.