### PR TITLE
strcmp optimization for riscv

### DIFF
--- a/COPYING.picolibc
+++ b/COPYING.picolibc
@@ -2845,7 +2845,7 @@ Files: .clang-format
  scripts/cross-riscv64-unknown-elf.txt
  scripts/cross-riscv64-zephyr-elf.txt
  scripts/cross-rv32imac.txt
- scripts/cross-rv32imac_zicsr.txt
+ scripts/cross-rv32imac_zicsr_zbb.txt
  scripts/cross-sh-unknown-elf.txt
  scripts/cross-sparc-zephyr-elf.txt
  scripts/cross-sparc64-linux-gnu.txt

--- a/newlib/libc/machine/riscv/strcmp.S
+++ b/newlib/libc/machine/riscv/strcmp.S
@@ -37,21 +37,25 @@ strcmp:
   and   a4, a4, SZREG-1
   bnez  a4, .Lmisaligned
 
+#ifndef __riscv_zbb
 #if SZREG == 4
   li a5, 0x7f7f7f7f
 #else
   ld a5, mask
 #endif
+#endif
 
   .macro check_one_word i n
     REG_L a2, \i*SZREG(a0)
     REG_L a3, \i*SZREG(a1)
-
+#ifdef __riscv_zbb
+    orc.b t0, a2
+#else
     and   t0, a2, a5
     or    t1, a2, a5
     add   t0, t0, a5
     or    t0, t0, t1
-
+#endif
     bne   t0, t2, .Lnull\i
     .if \i+1-\n
       bne   a2, a3, .Lmismatch
@@ -189,7 +193,7 @@ strcmp:
 #endif
 .size	strcmp, .-strcmp
 
-#if SZREG == 8
+#if SZREG == 8 && !defined(__riscv_zbb)
 .section .srodata.cst8,"aM",@progbits,8
 .align 3
 mask:

--- a/scripts/cross-rv32imac_zicsr_zbb.txt
+++ b/scripts/cross-rv32imac_zicsr_zbb.txt
@@ -14,8 +14,8 @@ cpu = 'riscv32'
 endian = 'little'
 
 [properties]
-c_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr', '-mabi=ilp32']
-c_link_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac', '-mabi=ilp32']
+c_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr_zbb', '-mabi=ilp32']
+c_link_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr_zbb', '-mabi=ilp32']
 skip_sanity_check = true
 default_flash_addr = '0x80000000'
 default_flash_size = '0x00200000'

--- a/scripts/do-rv32imac-configure
+++ b/scripts/do-rv32imac-configure
@@ -40,7 +40,7 @@ case "$version" in
 	arch=rv32imac
 	;;
     *)
-	arch=rv32imac_zicsr
+	arch=rv32imac_zicsr_zbb
 	;;
 esac
 exec "$(dirname "$0")"/do-configure "$arch" \

--- a/semihost/lseek.c
+++ b/semihost/lseek.c
@@ -60,15 +60,7 @@ off_t lseek(int fd, off_t offset, int whence)
 		return (off_t) -1;
 	}
 
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-	} arg = {
-		.field1 = fd,
-		.field2 = offset
-	};
-
-	uintptr_t ret = sys_semihost(SYS_SEEK, (uintptr_t) &arg);
+	uintptr_t ret = sys_semihost2(SYS_SEEK, fd, offset);
 	if (ret == 0)
 		return offset;
 	errno = sys_semihost_errno();

--- a/semihost/semihost-private.h
+++ b/semihost/semihost-private.h
@@ -77,5 +77,45 @@ typedef uintptr_t sh_param_t;
 uintptr_t
 sys_semihost(uintptr_t op, uintptr_t param);
 
+/* Helper functions to simplify semihosting calls with indirect arguments. */
+static inline uintptr_t
+sys_semihost1(long op, sh_param_t arg1)
+{
+    struct {
+        sh_param_t field1;
+    } indirect_args = {
+        .field1 = arg1,
+    };
+    return sys_semihost(op, (uintptr_t)&indirect_args);
+}
+
+static inline uintptr_t
+sys_semihost2(long op, sh_param_t arg1, sh_param_t arg2)
+{
+    struct {
+        sh_param_t field1;
+        sh_param_t field2;
+    } indirect_args = {
+        .field1 = arg1,
+        .field2 = arg2,
+    };
+    return sys_semihost(op, (uintptr_t)&indirect_args);
+}
+
+static inline uintptr_t
+sys_semihost3(long op, sh_param_t arg1, sh_param_t arg2, sh_param_t arg3)
+{
+    struct {
+        sh_param_t field1;
+        sh_param_t field2;
+        sh_param_t field3;
+    } indirect_args = {
+        .field1 = arg1,
+        .field2 = arg2,
+        .field3 = arg3,
+    };
+    return sys_semihost(op, (uintptr_t)&indirect_args);
+}
+
 int
 _map_stdio(int fd);

--- a/semihost/semihost.h
+++ b/semihost/semihost.h
@@ -155,7 +155,7 @@ int
 sys_semihost_tmpnam(char *pathname, int identifier, int maxpath);
 
 uintptr_t
-sys_semihost_write(int fd, const void *buf, uintptr_t count);
+sys_semihost_write(int fd, const void *buf, size_t count);
 
 void
 sys_semihost_write0(const char *string);

--- a/semihost/sys_close.c
+++ b/semihost/sys_close.c
@@ -38,10 +38,5 @@
 int
 sys_semihost_close(int fd)
 {
-	struct {
-		sh_param_t	field1;
-	} arg = {
-		.field1 = fd
-	};
-	return (int) sys_semihost(SYS_CLOSE, (uintptr_t) &arg);
+	return (int) sys_semihost1(SYS_CLOSE, fd);
 }

--- a/semihost/sys_exit.c
+++ b/semihost/sys_exit.c
@@ -40,14 +40,7 @@ _Noreturn void
 sys_semihost_exit(uintptr_t exception, uintptr_t subcode)
 {
 	if (sizeof(sh_param_t) == 8) {
-		struct {
-			sh_param_t	field1;
-			sh_param_t	field2;
-		} arg = {
-			.field1 = exception,
-			.field2 = subcode
-		};
-		(void) sys_semihost(SYS_EXIT, (uintptr_t) &arg);
+		(void) sys_semihost2(SYS_EXIT, exception, subcode);
 	}
 	else
 		(void) sys_semihost(SYS_EXIT, exception);

--- a/semihost/sys_exit_extended.c
+++ b/semihost/sys_exit_extended.c
@@ -39,13 +39,6 @@
 _Noreturn void
 sys_semihost_exit_extended(uintptr_t code)
 {
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-	} arg = {
-		.field1 = ADP_Stopped_ApplicationExit,
-		.field2 = code
-	};
-	(void) sys_semihost(SYS_EXIT_EXTENDED, (uintptr_t) &arg);
-	__unreachable();
+    (void)sys_semihost2(SYS_EXIT_EXTENDED, ADP_Stopped_ApplicationExit, code);
+    __unreachable();
 }

--- a/semihost/sys_flen.c
+++ b/semihost/sys_flen.c
@@ -38,11 +38,5 @@
 uintptr_t
 sys_semihost_flen(int fd)
 {
-	struct {
-		sh_param_t	field1;
-	} arg = {
-		.field1 = (sh_param_t) fd,
-	};
-
-	return (uintptr_t) sys_semihost(SYS_FLEN, (uintptr_t) &arg);
+    return (uintptr_t)sys_semihost1(SYS_FLEN, fd);
 }

--- a/semihost/sys_iserror.c
+++ b/semihost/sys_iserror.c
@@ -38,10 +38,5 @@
 int
 sys_semihost_iserror(intptr_t status)
 {
-	struct {
-		sh_param_t	field1;
-	} arg = {
-		.field1 = status
-	};
-	return (int) sys_semihost(SYS_ISERROR, (uintptr_t) &arg);
+    return (int)sys_semihost1(SYS_ISERROR, status);
 }

--- a/semihost/sys_istty.c
+++ b/semihost/sys_istty.c
@@ -38,10 +38,5 @@
 int
 sys_semihost_istty(int fd)
 {
-	struct {
-		sh_param_t	field1;
-	} arg = {
-		.field1 = fd
-	};
-	return (int) sys_semihost(SYS_ISTTY, (uintptr_t) &arg);
+    return (int)sys_semihost1(SYS_ISTTY, fd);
 }

--- a/semihost/sys_open.c
+++ b/semihost/sys_open.c
@@ -39,15 +39,6 @@
 int
 sys_semihost_open(const char *pathname, int semiflags)
 {
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-		sh_param_t	field3;
-	} arg = {
-		.field1 = (sh_param_t) (uintptr_t) pathname,
-		.field2 = semiflags,
-		.field3 = strlen(pathname)
-	};
-
-	return (int) sys_semihost(SYS_OPEN, (uintptr_t) &arg);
+    return (int)sys_semihost3(SYS_OPEN, (sh_param_t)(uintptr_t)pathname,
+                              semiflags, strlen(pathname));
 }

--- a/semihost/sys_read.c
+++ b/semihost/sys_read.c
@@ -38,15 +38,5 @@
 uintptr_t
 sys_semihost_read(int fd, void *buf, size_t count)
 {
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-		sh_param_t	field3;
-	} arg = {
-		.field1 = fd,
-		.field2 = (sh_param_t) (uintptr_t) buf,
-		.field3 = (sh_param_t) count
-	};
-
-	return sys_semihost(SYS_READ, (uintptr_t) &arg);
+    return sys_semihost3(SYS_READ, fd, (sh_param_t)(uintptr_t)buf, count);
 }

--- a/semihost/sys_remove.c
+++ b/semihost/sys_remove.c
@@ -39,13 +39,6 @@
 int
 sys_semihost_remove(const char *pathname)
 {
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-	} arg = {
-		.field1 = (sh_param_t) (uintptr_t) pathname,
-		.field2 = strlen(pathname)
-	};
-
-	return (int) sys_semihost(SYS_REMOVE, (uintptr_t) &arg);
+    return (int)sys_semihost2(SYS_REMOVE, (sh_param_t)(uintptr_t)pathname,
+                              strlen(pathname));
 }

--- a/semihost/sys_seek.c
+++ b/semihost/sys_seek.c
@@ -38,12 +38,5 @@
 int
 sys_semihost_seek(int fd, uintptr_t pos)
 {
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-	} arg = {
-		.field1 = fd,
-		.field2 = pos
-	};
-	return (int) sys_semihost(SYS_SEEK, (uintptr_t) &arg);
+    return (int)sys_semihost2(SYS_SEEK, fd, pos);
 }

--- a/semihost/sys_system.c
+++ b/semihost/sys_system.c
@@ -39,12 +39,5 @@
 int
 sys_semihost_system(const char *command)
 {
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-	} arg = {
-		.field1 = (uintptr_t) command,
-		.field2 = strlen(command)
-	};
-	return (int) sys_semihost(SYS_SYSTEM, (uintptr_t) &arg);
+    return (int)sys_semihost2(SYS_SYSTEM, (uintptr_t)command, strlen(command));
 }

--- a/semihost/sys_tmpnam.c
+++ b/semihost/sys_tmpnam.c
@@ -38,15 +38,6 @@
 int
 sys_semihost_tmpnam(char *pathname, int identifier, int maxpath)
 {
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-		sh_param_t	field3;
-	} arg = {
-		.field1 = (sh_param_t) (uintptr_t) pathname,
-		.field2 = identifier,
-		.field3 = maxpath
-	};
-
-	return (int) sys_semihost(SYS_TMPNAM, (uintptr_t) &arg);
+    return (int)sys_semihost3(SYS_TMPNAM, (sh_param_t)(uintptr_t)pathname,
+                              identifier, maxpath);
 }

--- a/semihost/sys_write.c
+++ b/semihost/sys_write.c
@@ -36,17 +36,8 @@
 #include "semihost-private.h"
 
 uintptr_t
-sys_semihost_write(int fd, const void *buf, uintptr_t count)
+sys_semihost_write(int fd, const void *buf, size_t count)
 {
-	struct {
-		sh_param_t	field1;
-		sh_param_t	field2;
-		sh_param_t	field3;
-	} arg = {
-		.field1 = fd,
-		.field2 = (sh_param_t) (uintptr_t) buf,
-		.field3 = (sh_param_t) count
-	};
-
-	return sys_semihost(SYS_WRITE, (uintptr_t) &arg);
+    return sys_semihost3(SYS_WRITE, fd, (sh_param_t)(uintptr_t)buf,
+                         count);
 }


### PR DESCRIPTION
Optimize strcmp by calling orc.b (OR-Combine) instruction when Zbb extension is supported instead of 4 instructions to detect if zero byte is exist in word