### PR TITLE
test sscanf.c

### DIFF
--- a/test/libc-testsuite/sscanf.c
+++ b/test/libc-testsuite/sscanf.c
@@ -281,6 +281,12 @@ static int test_sscanf(void)
         TEST_FV(INFINITY, "inf");
         TEST_FV(-INFINITY, "-inf");
 
+        a[0] = '#';
+        a[1] = '\0';
+        TEST(i, sscanf(" Nan(a1)", "%lf%c", &d, a), 1, "got %d fields, expected %d");
+        TEST(i, isnan(d), 1, "isnan %d expected %d");
+        TEST_S(a, "#", "");
+
         d = 1.0;
         TEST(i, sscanf("-inf", "%3lg", &d), 0, "got %d fields, expected %d");
         TEST(i, d, 1.0, "%g expected %g");


### PR DESCRIPTION
Quoting from C standard part 7.19.6.2

> a,e,f,g Matches an optionally signed floating-point number, infinity, or NaN, whose format is the same as expected for the subject sequence of the `strtod` function. The corresponding argument shall be a pointer to floating.

Regarding `strtod`, quoting from C standard part 7.20.1.3

> A character sequence NAN or NAN(n-char-sequence), is interpreted as a quiet NaN, if supported in the return type, else like a subject sequence part that does not have the expected form; the meaning of the n-char sequences is implementation-defined.