### PR TITLE
[picolib/ctype] Fix for conflict between C/POSIX for iswdigit()

### DIFF
--- a/newlib/libc/ctype/iswalnum.c
+++ b/newlib/libc/ctype/iswalnum.c
@@ -70,9 +70,5 @@ No supporting OS subroutines are required.
 int
 iswalnum (wint_t c)
 {
-#ifdef _MB_CAPABLE
-    return iswalnum_l (c, 0);
-#else
     return c < (wint_t)0x100 ? isalnum (c) : 0;
-#endif
 }

--- a/newlib/libc/ctype/iswdigit_l.c
+++ b/newlib/libc/ctype/iswdigit_l.c
@@ -3,11 +3,20 @@ Copyright (c) 2016 Corinna Vinschen <corinna@vinschen.de>
 Modified (m) 2017 Thomas Wolff: revise Unicode and locale/wchar handling
  */
 #define _DEFAULT_SOURCE
+#include <ctype.h>
 #include <wctype.h>
+#include "local.h"
+#include "categories.h"
 
 int
 iswdigit_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
+#ifdef _MB_CAPABLE
+  c = _jp2uc_l (c, locale);
+  enum category cat = category (c);
+  return cat == CAT_Nd; // Decimal_Number
+#else
   return c >= (wint_t)'0' && c <= (wint_t)'9';
+#endif /* _MB_CAPABLE */
 }


### PR DESCRIPTION
This commit is a trial fix to avoid the conflict between C & POSIX standard regarding the iswdigit() and iswdigit_l() functions as mentioned in the discussion : https://github.com/picolibc/picolibc/discussions/872

to define iswalnum to be how C defines it (iswalpha(c) || iswdigit(c)), and then define iswalnum_l to be iswalpha_l(c,l) || iswdigit_l(c, l)