### PR TITLE
tinystdio: Handled invalid sequence of characters

### DIFF
--- a/newlib/libc/tinystdio/conv_flt.c
+++ b/newlib/libc/tinystdio/conv_flt.c
@@ -394,8 +394,12 @@ conv_flt (FLT_STREAM *stream, FLT_CONTEXT *context, width_t width, void *addr, u
 	    if (!isdigit (edig))
             {
                 scanf_ungetc(edig, stream, context);
-                if (esign != EOF)
-                    scanf_ungetc(esign, stream, context);
+                if (esign != EOF) {
+                    esign = scanf_getc (stream, context);
+                    if(!isdigit (esign))
+                        return 0;
+                    scanf_ungetc(edig, stream, context);
+                    }
                 goto no_exp;
             }
 

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -279,6 +279,8 @@ conv_int (FILE *stream, scanf_context_t *context, width_t width, void *addr, uin
             base = 16;
             if (!--width || IS_EOF(i = scanf_getc (stream, context)))
 		goto putval;
+            if(!isxdigit(i))
+                goto err;
 #ifdef _NEED_IO_PERCENT_B
         } else if (i == 'b' && base <= 2) {
             base = 2;


### PR DESCRIPTION
Handled invalid hexadecimal sequence passed to the vfscanf function by using "isxdigit" to check for the full hex range and detect invalid entry. 
Handled if the exponent in the floating point is a valid entry by using "isdigit"