### PR TITLE
Fix stpcpy for RISC-V

### DIFF
--- a/newlib/libc/machine/riscv/rv_strcpy.h
+++ b/newlib/libc/machine/riscv/rv_strcpy.h
@@ -85,37 +85,46 @@ char *__libc_strcpy(char *dst, const char *src, bool ret_start)
     {
       uintxlen_t *pdst = (uintxlen_t *)dst;
       const uintxlen_t *psrc = (const uintxlen_t *)src;
+      uintxlen_t s;
 
-      while (!__libc_detect_null(*psrc))
-        *pdst++ = *psrc++;
+      while (!__libc_detect_null(s = *psrc))
+        {
+          *pdst++ = s;
+          psrc++;
+        }
 
       dst = (char *)pdst;
-      src = (const char *)psrc;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define SBYTE(s, i)        ((char) ((s) >> ((i) * 8)))
+#else
+#define SBYTE(s, i)        ((char) ((s) >> ((sizeof(s) - 1 - (i)) * 8)))
+#endif
 
       if (ret_start)
         {
-          if (!(*dst++ = src[0])) return dst0;
-          if (!(*dst++ = src[1])) return dst0;
-          if (!(*dst++ = src[2])) return dst0;
-          #if __riscv_xlen == 64
-            if (!(*dst++ = src[3])) return dst0;
-            if (!(*dst++ = src[4])) return dst0;
-            if (!(*dst++ = src[5])) return dst0;
-            if (!(*dst++ = src[6])) return dst0;
-          #endif
+          if (!(*dst++ = SBYTE(s, 0))) return dst0;
+          if (!(*dst++ = SBYTE(s, 1))) return dst0;
+          if (!(*dst++ = SBYTE(s, 2))) return dst0;
+#if __riscv_xlen == 64
+          if (!(*dst++ = SBYTE(s, 3))) return dst0;
+          if (!(*dst++ = SBYTE(s, 4))) return dst0;
+          if (!(*dst++ = SBYTE(s, 5))) return dst0;
+          if (!(*dst++ = SBYTE(s, 6))) return dst0;
+#endif
         }
       else
         {
-          if (!(*dst++ = src[0])) return dst - 1;
-          if (!(*dst++ = src[1])) return dst - 1;
-          if (!(*dst++ = src[2])) return dst - 1;
-          #if __riscv_xlen == 64
-            if (!(*dst++ = src[3])) return dst - 1;
-            if (!(*dst++ = src[4])) return dst - 1;
-            if (!(*dst++ = src[5])) return dst - 1;
-            if (!(*dst++ = src[6])) return dst - 1;
-            dst0 = dst;
-          #endif
+          if (!(*dst++ = SBYTE(s, 0))) return dst - 1;
+          if (!(*dst++ = SBYTE(s, 1))) return dst - 1;
+          if (!(*dst++ = SBYTE(s, 2))) return dst - 1;
+#if __riscv_xlen == 64
+          if (!(*dst++ = SBYTE(s, 3))) return dst - 1;
+          if (!(*dst++ = SBYTE(s, 4))) return dst - 1;
+          if (!(*dst++ = SBYTE(s, 5))) return dst - 1;
+          if (!(*dst++ = SBYTE(s, 6))) return dst - 1;
+#endif
+          dst0 = dst;
         }
 
       *dst = 0;


### PR DESCRIPTION
There is a bug in our Picolibc repository in the implementation of `stpcpy` for RISC-V. It works incorrectly with `src` strings with some lengths (e.g., when length is just 3 bytes). There is a new commit in upstream which accidently fixes this issue: https://github.com/foss-for-synopsys-dwc-arc-processors/picolibc/commit/5d90fafeb7fb6448b0cdd0d42c04a29f667ace76. And this commit is going to be pushed in this PR.

That commit fixes the issue because `dst0 = dst;` was moved out of `#if __riscv_xlen == 64` block.