### PR TITLE
Improve support of ARC Classic (ARCompact and ARCv2) in Picolibc

### DIFF
--- a/libm/test/meson.build
+++ b/libm/test/meson.build
@@ -153,6 +153,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   if target.strip('_') in skip_math_test
     continue
   endif

--- a/meson.build
+++ b/meson.build
@@ -82,6 +82,8 @@ endif
 cpu_family_aliases = {
 		       # aarch64
 		       'arm64' : 'aarch64',
+		       # ARCv3
+		       'arc32' : 'arc64',
 		       # cris
 		       'crisv32' : 'cris',
            # loongarch

--- a/picocrt/machine/arc/crt0.c
+++ b/picocrt/machine/arc/crt0.c
@@ -35,6 +35,15 @@
 
 #include "../../crt0.h"
 
+/* Define __ARCEM__ and __ARCHS__ for older GCC for ARC */
+#if defined (__EM__) && !defined (__ARCEM__)
+#define __ARCEM__ 1
+#endif
+
+#if defined (__HS__) && !defined (__ARCHS__)
+#define __ARCHS__ 1
+#endif
+
 static void __used __section(".init")
 _cstart(void)
 {
@@ -42,6 +51,8 @@ _cstart(void)
 }
 
 extern char __stack[];
+extern char __SDATA_BEGIN__[];
+extern char __JLI_TABLE__[];
 extern void(* const __vector_table[]);
 
 #ifdef __ARC64_ARCH64__
@@ -59,11 +70,69 @@ typedef uint32_t reg_t;
 void __naked __section(".init") __used
 _start(void)
 {
+    /**
+     * Set STATUS32.AD bit to enable referencing unaligned
+     * memory addresses for ARC HS
+     */
+#ifdef __ARCHS__
+    __asm__(LRR " r2, [0xA]\n"
+            "bset r2, r2, 19\n"
+            "flag r2");
+#endif
+
+    /* Initialize JLI (Jump and Link Indexed) table */
+#ifdef __ARC_CODE_DENSITY__
+    __asm__(SRR " %0, [jli_base]" : : "r"(__JLI_TABLE__));
+#endif
+
     /* Set up the stack pointer */
-    __asm__("mov_s sp, %0" : : "r"(__stack));
+    __asm__("mov sp, %0" : : "r"(__stack));
+
+    /* Set up the global pointer */
+    __asm__("mov gp, %0" : : "r"(__SDATA_BEGIN__));
 
     /* Set up the vector table */
     __asm__(SRR " %0, [0x25]" : : "r"(__vector_table));
+
+    /* Clear the registers except r26 (GP) and r28 (SP) */
+    __asm__("mov_s r0, 0\n"
+            "mov_s r1, 0\n"
+            "mov_s r2, 0\n"
+            "mov_s r3, 0\n"
+#ifndef __ARC_RF16__
+            "mov r4, 0\n"
+            "mov r5, 0\n"
+            "mov r6, 0\n"
+            "mov r7, 0\n"
+            "mov r8, 0\n"
+            "mov r9, 0\n"
+#endif
+            "mov r10, 0\n"
+            "mov r11, 0\n"
+            "mov_s r12, 0\n"
+            "mov_s r13, 0\n"
+            "mov_s r14, 0\n"
+            "mov_s r15, 0\n"
+#ifndef __ARC_RF16__
+            "mov r16, 0\n"
+            "mov r17, 0\n"
+            "mov r18, 0\n"
+            "mov r19, 0\n"
+            "mov r20, 0\n"
+            "mov r21, 0\n"
+            "mov r22, 0\n"
+            "mov r23, 0\n"
+            "mov r24, 0\n"
+            "mov r25, 0\n"
+#endif
+            "mov r27, 0\n"
+#if defined (__ARCEM__) || defined (__ARCHS__)
+            "mov ilink, 0\n"
+            "mov r30, 0\n");
+#else
+            "mov ilink1, 0\n"
+            "mov ilink2, 0\n");
+#endif
 
     /* Branch to C code */
     __asm__("j _cstart");
@@ -147,6 +216,8 @@ arc_fault(struct fault *f, int reason)
     _exit(1);
 }
 
+#ifndef __ARC_RF16__
+
 #define VECTOR_COMMON                                                   \
     __asm__(PUSH "  r31\n " PUSH " r30\n " PUSH " r29\n " PUSH " r28"); \
     __asm__(PUSH "  r27\n " PUSH " r26\n " PUSH " r25\n " PUSH " r24"); \
@@ -162,6 +233,22 @@ arc_fault(struct fault *f, int reason)
     __asm__(LRR " r0, [0x401]\n " PUSH " r0");                          \
     __asm__(LRR " r0, [0x400]\n " PUSH " r0");                          \
     __asm__("mov_s r0, sp")
+
+#else
+
+#define VECTOR_COMMON                                                   \
+    __asm__(PUSH "  r31\n " PUSH " r30\n " PUSH " r29\n " PUSH " r28"); \
+    __asm__(PUSH "  r27\n " PUSH " r26\n " PUSH " r15\n " PUSH " r14"); \
+    __asm__(PUSH "  r13\n " PUSH " r12\n " PUSH " r11\n " PUSH " r10"); \
+    __asm__(PUSH "   r3\n " PUSH "  r2\n " PUSH "  r1\n " PUSH "  r0"); \
+    __asm__(LRR " r0, [0x404]\n " PUSH " r0");                          \
+    __asm__(LRR " r0, [0x403]\n " PUSH " r0");                          \
+    __asm__(LRR " r0, [0x402]\n " PUSH " r0");                          \
+    __asm__(LRR " r0, [0x401]\n " PUSH " r0");                          \
+    __asm__(LRR " r0, [0x400]\n " PUSH " r0");                          \
+    __asm__("mov_s r0, sp")
+
+#endif
 
 void __naked __section(".init")
 arc_memory_error_vector(void)

--- a/picocrt/machine/arc64/crt0.c
+++ b/picocrt/machine/arc64/crt0.c
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * Copyright © 2019 Keith Packard
+ * Copyright © 2024, Synopsys Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,15 +35,6 @@
 
 #include "../../crt0.h"
 
-/* Define __ARCEM__ and __ARCHS__ for older GCC for ARC */
-#if defined (__EM__) && !defined (__ARCEM__)
-#define __ARCEM__ 1
-#endif
-
-#if defined (__HS__) && !defined (__ARCHS__)
-#define __ARCHS__ 1
-#endif
-
 static void __used __section(".init")
 _cstart(void)
 {
@@ -51,81 +42,93 @@ _cstart(void)
 }
 
 extern char __stack[];
-extern char __SDATA_BEGIN__[];
-extern char __JLI_TABLE__[];
 extern void(* const __vector_table[]);
-
+/**
+ * Below 2 different macros are defined for MOV:
+ * 
+ *     1. MOV. For 64-bit targets it uses movl and for 32-bit targets
+ *        it uses mov_s. For this crt0 it's enough to pack all values
+ *        to fit in encodings. We dont's used movl_s for 64-bit by default
+ *        because it does not support the same range of registers as
+ *        mov_s for 32-bit targets.
+ *     2. MOV_S. This macro must be used if we are sure that everything
+ *        will fit in mov_s/movl_s.
+ */
+#ifdef __ARC64_ARCH64__
+#define SRR  "srl"
+#define LRR  "lrl"
+#define PUSH "pushl"
+#define MOV "movl"
+#define MOV_S "movl_s"
+typedef uint64_t reg_t;
+#else
 #define SRR  "sr"
 #define LRR  "lr"
 #define PUSH "push"
+#define MOV "mov_s"
+#define MOV_S "mov_s"
 typedef uint32_t reg_t;
+#endif
 
 void __naked __section(".init") __used
 _start(void)
 {
     /**
      * Set STATUS32.AD bit to enable referencing unaligned
-     * memory addresses for ARC HS
+     * memory addresses
      */
-#ifdef __ARCHS__
     __asm__(LRR " r2, [0xA]\n"
             "bset r2, r2, 19\n"
             "flag r2");
+
+    /* Set up the stack pointer and the vector table */
+#ifdef __ARC64_ARCH64__
+    /**
+     * 64-bit absolute addresses are loaded with a pair of instructions
+     * which have an associated pair of relocations: R_ARC_LO32_ME and
+     * R_ARC_HI32_ME.
+     */
+    __asm__("movhl_s sp, %0" : : "i"(__stack));
+    __asm__("orl_s sp, sp, %0" : : "i"(__stack));
+
+    __asm__("movhl_s r2, %0" : : "i"(__vector_table));
+    __asm__("orl_s r2, r2, %0" : : "i"(__vector_table));
+    __asm__("srl r2, [0x25]");
+#else
+    __asm__("mov_s sp, %0" : : "i"(__stack));
+    __asm__("sr %0, [0x25]" : : "i"(__vector_table));
 #endif
-
-    /* Initialize JLI (Jump and Link Indexed) table */
-#ifdef __ARC_CODE_DENSITY__
-    __asm__(SRR " %0, [jli_base]" : : "r"(__JLI_TABLE__));
-#endif
-
-    /* Set up the stack pointer */
-    __asm__("mov sp, %0" : : "i"(__stack));
-
-    /* Set up the global pointer */
-    __asm__("mov gp, %0" : : "i"(__SDATA_BEGIN__));
-
-    /* Set up the vector table */
-    __asm__(SRR " %0, [0x25]" : : "i"(__vector_table));
 
     /* Clear the registers except r26 (GP) and r28 (SP) */
-    __asm__("mov_s r0, 0\n"
-            "mov_s r1, 0\n"
-            "mov_s r2, 0\n"
-            "mov_s r3, 0\n"
-#ifndef __ARC_RF16__
-            "mov r4, 0\n"
-            "mov r5, 0\n"
-            "mov r6, 0\n"
-            "mov r7, 0\n"
-            "mov r8, 0\n"
-            "mov r9, 0\n"
-#endif
-            "mov r10, 0\n"
-            "mov r11, 0\n"
-            "mov_s r12, 0\n"
-            "mov_s r13, 0\n"
-            "mov_s r14, 0\n"
-            "mov_s r15, 0\n"
-#ifndef __ARC_RF16__
-            "mov r16, 0\n"
-            "mov r17, 0\n"
-            "mov r18, 0\n"
-            "mov r19, 0\n"
-            "mov r20, 0\n"
-            "mov r21, 0\n"
-            "mov r22, 0\n"
-            "mov r23, 0\n"
-            "mov r24, 0\n"
-            "mov r25, 0\n"
-#endif
-            "mov r27, 0\n"
-#if defined (__ARCEM__) || defined (__ARCHS__)
-            "mov ilink, 0\n"
-            "mov r30, 0\n");
-#else
-            "mov ilink1, 0\n"
-            "mov ilink2, 0\n");
-#endif
+    __asm__(MOV " r0, 0\n"
+            MOV " r1, 0\n"
+            MOV " r2, 0\n"
+            MOV " r3, 0\n"
+            MOV " r4, 0\n"
+            MOV " r5, 0\n"
+            MOV " r6, 0\n"
+            MOV " r7, 0\n"
+            MOV " r8, 0\n"
+            MOV " r9, 0\n"
+            MOV " r10, 0\n"
+            MOV " r11, 0\n"
+            MOV " r12, 0\n"
+            MOV " r13, 0\n"
+            MOV " r14, 0\n"
+            MOV " r15, 0\n"
+            MOV " r16, 0\n"
+            MOV " r17, 0\n"
+            MOV " r18, 0\n"
+            MOV " r19, 0\n"
+            MOV " r20, 0\n"
+            MOV " r21, 0\n"
+            MOV " r22, 0\n"
+            MOV " r23, 0\n"
+            MOV " r24, 0\n"
+            MOV " r25, 0\n"
+            MOV " r27, 0\n"
+            MOV " ilink, 0\n"
+            MOV " r30, 0\n");
 
     /* Branch to C code */
     __asm__("j _cstart");
@@ -209,8 +212,6 @@ arc_fault(struct fault *f, int reason)
     _exit(1);
 }
 
-#ifndef __ARC_RF16__
-
 #define VECTOR_COMMON                                                   \
     __asm__(PUSH "  r31\n " PUSH " r30\n " PUSH " r29\n " PUSH " r28"); \
     __asm__(PUSH "  r27\n " PUSH " r26\n " PUSH " r25\n " PUSH " r24"); \
@@ -225,29 +226,13 @@ arc_fault(struct fault *f, int reason)
     __asm__(LRR " r0, [0x402]\n " PUSH " r0");                          \
     __asm__(LRR " r0, [0x401]\n " PUSH " r0");                          \
     __asm__(LRR " r0, [0x400]\n " PUSH " r0");                          \
-    __asm__("mov_s r0, sp")
-
-#else
-
-#define VECTOR_COMMON                                                   \
-    __asm__(PUSH "  r31\n " PUSH " r30\n " PUSH " r29\n " PUSH " r28"); \
-    __asm__(PUSH "  r27\n " PUSH " r26\n " PUSH " r15\n " PUSH " r14"); \
-    __asm__(PUSH "  r13\n " PUSH " r12\n " PUSH " r11\n " PUSH " r10"); \
-    __asm__(PUSH "   r3\n " PUSH "  r2\n " PUSH "  r1\n " PUSH "  r0"); \
-    __asm__(LRR " r0, [0x404]\n " PUSH " r0");                          \
-    __asm__(LRR " r0, [0x403]\n " PUSH " r0");                          \
-    __asm__(LRR " r0, [0x402]\n " PUSH " r0");                          \
-    __asm__(LRR " r0, [0x401]\n " PUSH " r0");                          \
-    __asm__(LRR " r0, [0x400]\n " PUSH " r0");                          \
-    __asm__("mov_s r0, sp")
-
-#endif
+    __asm__(MOV " r0, sp")
 
 void __naked __section(".init")
 arc_memory_error_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_MEMORY_ERROR));
+    __asm__(MOV_S " r1, " REASON(REASON_MEMORY_ERROR));
     __asm__("j arc_fault");
 }
 
@@ -255,7 +240,7 @@ void __naked __section(".init")
 arc_instruction_error_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_INSTRUCTION_ERROR));
+    __asm__(MOV_S " r1, " REASON(REASON_INSTRUCTION_ERROR));
     __asm__("j arc_fault");
 }
 
@@ -263,7 +248,7 @@ void __naked __section(".init")
 arc_machine_check_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_MACHINE_CHECK));
+    __asm__(MOV_S " r1, " REASON(REASON_MACHINE_CHECK));
     __asm__("j arc_fault");
 }
 
@@ -271,7 +256,7 @@ void __naked __section(".init")
 arc_tlb_miss_i_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_TLB_MISS_I));
+    __asm__(MOV_S " r1, " REASON(REASON_TLB_MISS_I));
     __asm__("j arc_fault");
 }
 
@@ -279,7 +264,7 @@ void __naked __section(".init")
 arc_tlb_miss_d_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_TLB_MISS_D));
+    __asm__(MOV_S " r1, " REASON(REASON_TLB_MISS_D));
     __asm__("j arc_fault");
 }
 
@@ -287,7 +272,7 @@ void __naked __section(".init")
 arc_prot_v_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_PROT_V));
+    __asm__(MOV_S " r1, " REASON(REASON_PROT_V));
     __asm__("j arc_fault");
 }
 
@@ -295,7 +280,7 @@ void __naked __section(".init")
 arc_privilege_v_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_PRIVILEGE_V));
+    __asm__(MOV_S " r1, " REASON(REASON_PRIVILEGE_V));
     __asm__("j arc_fault");
 }
 
@@ -303,7 +288,7 @@ void __naked __section(".init")
 arc_swi_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_SWI));
+    __asm__(MOV_S " r1, " REASON(REASON_SWI));
     __asm__("j arc_fault");
 }
 
@@ -311,7 +296,7 @@ void __naked __section(".init")
 arc_trap_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_TRAP));
+    __asm__(MOV_S " r1, " REASON(REASON_TRAP));
     __asm__("j arc_fault");
 }
 
@@ -319,7 +304,7 @@ void __naked __section(".init")
 arc_extension_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_EXTENSION));
+    __asm__(MOV_S " r1, " REASON(REASON_EXTENSION));
     __asm__("j arc_fault");
 }
 
@@ -327,7 +312,7 @@ void __naked __section(".init")
 arc_div_zero_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_DIV_ZERO));
+    __asm__(MOV_S " r1, " REASON(REASON_DIV_ZERO));
     __asm__("j arc_fault");
 }
 
@@ -335,7 +320,7 @@ void __naked __section(".init")
 arc_dc_error_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_DC_ERROR));
+    __asm__(MOV_S " r1, " REASON(REASON_DC_ERROR));
     __asm__("j arc_fault");
 }
 
@@ -343,7 +328,7 @@ void __naked __section(".init")
 arc_maligned_vector(void)
 {
     VECTOR_COMMON;
-    __asm__("mov_s r1, " REASON(REASON_MALIGNED));
+    __asm__(MOV_S " r1, " REASON(REASON_MALIGNED));
     __asm__("j arc_fault");
 }
 #endif

--- a/picocrt/machine/arc64/meson.build
+++ b/picocrt/machine/arc64/meson.build
@@ -32,4 +32,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-src_picocrt += files('../arc/crt0.c')
+src_picocrt += files('crt0.c')

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -157,20 +157,22 @@ if thread_local_storage
   }
 endif
 
-arcv_picocrt_variants = []
+if host_cpu_family == 'riscv'
+  arcv_picocrt_variants = []
 
-foreach variant : picocrt_variants
-  if variant['name'] != 'none'
-    arcv_picocrt_variants += {
-      'name': 'arcv-' + variant['name'],
-      'suffix': '-arcv' + variant['suffix'],
-      'c_args': variant['c_args'] + ['-DCRT0_ARCV'],
-      'src': variant['src'],
-    }
-  endif
-endforeach
+  foreach variant : picocrt_variants
+    if variant['name'] != 'none'
+      arcv_picocrt_variants += {
+        'name': 'arcv-' + variant['name'],
+        'suffix': '-arcv' + variant['suffix'],
+        'c_args': variant['c_args'] + ['-DCRT0_ARCV'],
+        'src': variant['src'],
+      }
+    endif
+  endforeach
 
-picocrt_variants += arcv_picocrt_variants
+  picocrt_variants += arcv_picocrt_variants
+endif
 
 foreach params : targets
   target = params['name']

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -186,6 +186,14 @@ SECTIONS
 @BFD@	PROVIDE( @PREFIX@__plt_size = SIZEOF(.plt) );
 
 	/*
+	 * JLI (Jump and Link Indexed) table for ARC Classic
+	 */
+	.jlitab : {
+		PROVIDE( @PREFIX@__JLI_TABLE__ = .);
+		jlitab*.o:(.jlitab*) *(.jlitab*)
+	} >@RODATA_MEM@ AT>@RODATA_AT@ :@RODATA_PHDR@
+
+	/*
 	 * Needs to be in its own segment with the PLT entries first
 	 * so that the linker will compute the offsets to those
 	 * entries correctly.
@@ -465,6 +473,8 @@ SECTIONS
 	.debug_str_offsets 0 : { *(.debug_str_offsets) }
 	.debug_sup      0 : { *(.debug_sup) }
 	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+	/* ARC extension sections */
+	.arcextmap      0 : { *(.arcextmap.*) }
 }
 /*
  * Check that sections that are copied from flash to RAM have matching

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -126,6 +126,7 @@ SECTIONS
 @CPP@	} >@RODATA_MEM@ AT>@RODATA_AT@ :@RODATA_PHDR@
 
 	.rodata : {
+		PROVIDE( @PREFIX@__SDATA_BEGIN__ = . );
 
 		/* read-only data */
 		*(.rdata)

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -15,8 +15,11 @@
 *link:
 @SPECS_PRINTF@ @SPECS_LIBPATH@ %{-printf=*:--defsym=@PREFIX@vfprintf=@PREFIX@__%*_vfprintf} %{-scanf=*:--defsym=@PREFIX@vfscanf=@PREFIX@__%*_vfscanf} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@
 
+*link_gcc_c_sequence:
+--start-group %(libgcc) -lc %{-oslib=*:-l%*} --end-group
+
 *lib:
---start-group %(libgcc) @ADDITIONAL_LIBS@ -lc %{-oslib=*:-l%*} --end-group
+
 
 *endfile:
 @CRTEND@

--- a/scripts/cross-arc-snps-elf.txt
+++ b/scripts/cross-arc-snps-elf.txt
@@ -1,0 +1,23 @@
+[binaries]
+c = ['arc-snps-elf-gcc', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
+cpp = ['arc-snps-elf-g++', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
+ar = 'arc-snps-elf-ar'
+as = 'arc-snps-elf-as'
+nm = 'arc-snps-elf-nm'
+strip = 'arc-snps-elf-strip'
+# only needed to run tests
+exe_wrapper = ['env', 'run-arc']
+
+[host_machine]
+system = 'snps'
+cpu_family = 'arc'
+cpu = 'arc'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+has_link_defsym = true
+default_flash_addr = '0x00000000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x00400000'
+default_ram_size   = '0x00400000'

--- a/scripts/cross-arc32-snps-elf.txt
+++ b/scripts/cross-arc32-snps-elf.txt
@@ -1,0 +1,23 @@
+[binaries]
+c = ['arc32-snps-elf-gcc', '-nostdlib']
+cpp = ['arc32-snps-elf-g++', '-nostdlib']
+ar = 'arc32-snps-elf-ar'
+as = 'arc32-snps-elf-as'
+nm = 'arc32-snps-elf-nm'
+strip = 'arc32-snps-elf-strip'
+# only needed to run tests
+exe_wrapper = ['env', 'run-arc']
+
+[host_machine]
+system = 'snps'
+cpu_family = 'arc32'
+cpu = 'arc32'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+has_link_defsym = true
+default_flash_addr = '0x00000000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x00400000'
+default_ram_size   = '0x00400000'

--- a/scripts/cross-arc64-snps-elf.txt
+++ b/scripts/cross-arc64-snps-elf.txt
@@ -1,0 +1,23 @@
+[binaries]
+c = ['arc64-snps-elf-gcc', '-nostdlib']
+cpp = ['arc64-snps-elf-g++', '-nostdlib']
+ar = 'arc64-snps-elf-ar'
+as = 'arc64-snps-elf-as'
+nm = 'arc64-snps-elf-nm'
+strip = 'arc64-snps-elf-strip'
+# only needed to run tests
+exe_wrapper = ['env', 'run-arc']
+
+[host_machine]
+system = 'snps'
+cpu_family = 'arc64'
+cpu = 'arc64'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+has_link_defsym = true
+default_flash_addr = '0x00000000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x00400000'
+default_ram_size   = '0x00400000'

--- a/scripts/run-arc
+++ b/scripts/run-arc
@@ -69,6 +69,12 @@ readelf="arc-zephyr-elf-readelf"
 if ! which $readelf >/dev/null 2>/dev/null; then
     readelf="arc-snps-elf-readelf"
 fi
+if ! which $readelf >/dev/null 2>/dev/null; then
+    readelf="arc32-snps-elf-readelf"
+fi
+if ! which $readelf >/dev/null 2>/dev/null; then
+    readelf="arc64-snps-elf-readelf"
+fi
 
 # If readelf is installed, we can use the attributes
 # in the file to determine the target cpu

--- a/scripts/run-arc
+++ b/scripts/run-arc
@@ -64,7 +64,12 @@ while [ $# -gt 0 -a $done -eq 0 ]; do
 done
 
 archstring=""
+
 readelf="arc-zephyr-elf-readelf"
+if ! which $readelf >/dev/null 2>/dev/null; then
+    readelf="arc-snps-elf-readelf"
+fi
+
 # If readelf is installed, we can use the attributes
 # in the file to determine the target cpu
 if command -v "$readelf" >/dev/null 2>/dev/null; then

--- a/semihost/meson.build
+++ b/semihost/meson.build
@@ -55,6 +55,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _src = get_variable('src_semihost_' + target, src_semihost)
 
   if _src == []

--- a/test/libc-testsuite/meson.build
+++ b/test/libc-testsuite/meson.build
@@ -55,6 +55,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/meson.build
+++ b/test/meson.build
@@ -109,6 +109,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -84,6 +84,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   _libs += [get_variable('lib_semihost' + target)]
   if is_variable(crt0_test + target)

--- a/test/test-ctype/meson.build
+++ b/test/test-ctype/meson.build
@@ -50,6 +50,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/test-iconv/meson.build
+++ b/test/test-iconv/meson.build
@@ -42,6 +42,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/test-math/meson.build
+++ b/test/test-math/meson.build
@@ -115,6 +115,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/test-monetary/meson.build
+++ b/test/test-monetary/meson.build
@@ -42,6 +42,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/test-stdio/meson.build
+++ b/test/test-stdio/meson.build
@@ -125,6 +125,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/test-string/meson.build
+++ b/test/test-string/meson.build
@@ -59,6 +59,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/testsuite/newlib.iconv/meson.build
+++ b/test/testsuite/newlib.iconv/meson.build
@@ -40,6 +40,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/testsuite/newlib.locale/meson.build
+++ b/test/testsuite/newlib.locale/meson.build
@@ -46,6 +46,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/testsuite/newlib.search/meson.build
+++ b/test/testsuite/newlib.search/meson.build
@@ -40,6 +40,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/testsuite/newlib.stdio/meson.build
+++ b/test/testsuite/newlib.stdio/meson.build
@@ -40,6 +40,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/testsuite/newlib.stdlib/meson.build
+++ b/test/testsuite/newlib.stdlib/meson.build
@@ -40,6 +40,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/testsuite/newlib.string/meson.build
+++ b/test/testsuite/newlib.string/meson.build
@@ -40,6 +40,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/testsuite/newlib.time/meson.build
+++ b/test/testsuite/newlib.time/meson.build
@@ -40,6 +40,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]

--- a/test/testsuite/newlib.wctype/meson.build
+++ b/test/testsuite/newlib.wctype/meson.build
@@ -42,6 +42,18 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  if host_cpu_family == 'arc'
+    has_rf16_code = '''
+    #ifndef __ARC_RF16__
+    #error __ARC_RF16__ is not defined
+    #endif
+    '''
+
+    if cc.compiles(has_rf16_code, args: target_c_args + c_args)
+      continue
+    endif
+  endif
+
   _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]


### PR DESCRIPTION
This PR introduces a series of fixes and updated for Picolibc to get it work for baremetal ARCompact and ARCv2 targets:

1. Import all `crt0` features from Newlib.
2. Fix `.specs` and `.ld` files for ARC Classic.
3. Fix building with ARC EM mini targets (exclude tests and semihosting from these targets).
4. Add extra default cross files for general ARC Classic targets.
5. Fix a run script.

What is not ready yet:

1. ~~Full support of ARCv3. I am working on rewriting `crt0` for ARCv3 to make it fully compatible with Newlib version.~~
2. Support of HSDK and EM SDP boards is not ready yet.