### PR TITLE
Port Hostlink support from Newlib 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1945,6 +1945,6 @@ if not enable_multilib and meson.is_subproject()
   picolibc_dep = declare_dependency(include_directories: inc, link_with: [lib_c])
 endif
 
-if host_cpu_family == 'arc'
-  subdir('platforms/arc')
+if host_cpu_family in ['arc', 'arc64']
+  subdir('platforms' / host_cpu_family)
 endif

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -174,6 +174,37 @@ if host_cpu_family == 'riscv'
   picocrt_variants += arcv_picocrt_variants
 endif
 
+if host_cpu_family in ['arc', 'arc64']
+  arc_picocrt_variants = [
+    {
+      'name': 'hl',
+      'suffix': '-hl',
+      'c_args':  ['-DCRT0_EXIT', '-DCRT0_GET_CMDLINE'],
+      'src': src_picocrt,
+    },
+    {
+      'name': 'hl-trap',
+      'suffix': '-hl-trap',
+      'c_args':  ['-DCRT0_EXIT', '-DCRT0_GET_CMDLINE', '-DCRT0_SEMIHOST_TRAP'],
+      'src': src_picocrt,
+    },
+    {
+      'name': 'noflash-hl',
+      'suffix': '-noflash-hl',
+      'c_args': ['-DINIT_TLS', '-DNO_FLASH', '-DCRT0_EXIT', '-DCRT0_GET_CMDLINE'],
+      'src': src_picocrt,
+    },
+    {
+      'name': 'noflash-hl-trap',
+      'suffix': '-noflash-hl-trap',
+      'c_args': ['-DINIT_TLS', '-DNO_FLASH', '-DCRT0_EXIT', '-DCRT0_GET_CMDLINE', '-DCRT0_SEMIHOST_TRAP'],
+      'src': src_picocrt,
+    },
+  ]
+
+  picocrt_variants += arc_picocrt_variants
+endif
+
 foreach params : targets
   target = params['name']
   target_dir = params['dir']

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -126,7 +126,6 @@ SECTIONS
 @CPP@	} >@RODATA_MEM@ AT>@RODATA_AT@ :@RODATA_PHDR@
 
 	.rodata : {
-		PROVIDE( @PREFIX@__SDATA_BEGIN__ = . );
 
 		/* read-only data */
 		*(.rdata)
@@ -252,6 +251,7 @@ SECTIONS
 		/* Need to pre-align so that the symbols come after padding */
 		. = ALIGN(@DEFAULT_ALIGNMENT@);
 
+		PROVIDE( @PREFIX@__SDATA_BEGIN__ = . + 0x100 );
 		PROVIDE( @PREFIX@__global_pointer$ = . + 0x800 );
 		PROVIDE( @PREFIX@_gp = . + 0x8000);
 		*(.sdata .sdata.* .sdata2.* @EXTRA_SDATA_SECTIONS@)

--- a/platforms/arc/hl_api.c
+++ b/platforms/arc/hl_api.c
@@ -1,0 +1,365 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* High-level Hostlink IO API. */
+
+#include <string.h>
+#include <stdarg.h>
+
+#include "hl_gw.h"
+#include "hl_api.h"
+
+/* Parameter types. */
+#define PAT_CHAR   1
+#define PAT_SHORT  2
+#define PAT_INT    3
+#define PAT_STRING 4
+/* For future use. */
+#define PAT_INT64 5
+
+/* Used internally to pass user hostlink parameters to _hl_message(). */
+struct _hl_user_info {
+    uint32_t vendor_id;
+    uint32_t opcode;
+    uint32_t result;
+};
+
+/*
+ * Main function to send a message using hostlink. Arguments:
+ *
+ * syscall
+ *
+ *     One of HL_SYSCALL_* defines from hl_api.h.
+ *
+ * user
+ *
+ *     Parameters and return value for _user_hostlink implementation.
+ *     Packing structure:
+ *
+ *         uint32 vendor_id - user-defined vendor ID. ID 1025 is reserved for
+ *                            GNU IO extensions.
+ *         uint32 opcode    - operation code for user-defined hostlink.
+ *         char format[]    - argument string in the same format as for
+ *                            _hl_message() function, see below.
+ *
+ * format
+ * 
+ *     Argument and return values format string [(i4sp)*:?(i4sp)*], where
+ *     characters before ':' is arguments and after is return values.
+ *     Supported format characters:
+ *
+ *         i or 4 - uint32 value, pack_int will be used;
+ *         s      - char * data, pack_str will be used;
+ *         p      - void * data, pack_ptr will be used.
+ *
+ * ap
+ * 
+ *     Argument values and pointers to the output values. Must be in sync
+ *     with format string. For hostlink message argument:
+ *
+ *         i or 4 - uint32 value;
+ *         s      - char * pointer to the NULL-terminated string;
+ *         p      - void * pointer to the buffer and uint32 buffer length.
+ *
+ *     For output values:
+ *
+ *         i or 4 - uint32 * pointer to uint32 to return;
+ *         s      - char * pointer to buffer to return, it must have enough
+ *                  space to store returned data. You can get packed buffer
+ *                  length with _hl_get_ptr_len();
+ *         p      - void * pointer and uint32 * length pointer to store
+ *                  returned data along with length.  Buffer must be enough
+ *                  to store returned data. You can get packed buffer length
+ *                  with _hl_get_ptr_len();
+ *
+ * Returns a pointer to the hostlink buffer after output values.
+ */
+static volatile __uncached char *
+_hl_message_va(uint32_t syscall, struct _hl_user_info *user, const char *format, va_list ap)
+{
+    const char               *f = format;
+    volatile __uncached char *p = _hl_payload();
+    int                       get_answer = 0;
+
+    p = _hl_pack_int(p, syscall);
+
+    if (syscall == HL_SYSCALL_USER) {
+        p = _hl_pack_int(p, user->vendor_id);
+        p = _hl_pack_int(p, user->opcode);
+        p = _hl_pack_str(p, format);
+    }
+
+    for (; *f; f++) {
+        void    *ptr;
+        uint32_t len;
+
+        if (*f == ':') {
+            f++;
+            get_answer = 1;
+            break;
+        }
+
+        switch (*f) {
+        case 'i':
+        case '4':
+            p = _hl_pack_int(p, va_arg(ap, uint32_t));
+            break;
+        case 's':
+            p = _hl_pack_str(p, va_arg(ap, char *));
+            break;
+        case 'p':
+            ptr = va_arg(ap, void *);
+            len = va_arg(ap, uint32_t);
+            p = _hl_pack_ptr(p, ptr, len);
+            break;
+        default:
+            return NULL;
+        }
+
+        if (p == NULL)
+            return NULL;
+    }
+
+    _hl_send(p);
+
+    p = _hl_recv();
+
+    if (syscall == HL_SYSCALL_USER && p)
+        p = _hl_unpack_int(p, &user->result);
+
+    if (p && get_answer) {
+        for (; *f; f++) {
+            void     *ptr;
+            uint32_t *plen;
+
+            switch (*f) {
+            case 'i':
+            case '4':
+                p = _hl_unpack_int(p, va_arg(ap, uint32_t *));
+                break;
+            case 's':
+                p = _hl_unpack_str(p, va_arg(ap, char *));
+                break;
+            case 'p':
+                ptr = va_arg(ap, void *);
+                plen = va_arg(ap, uint32_t *);
+                p = _hl_unpack_ptr(p, ptr, plen);
+                break;
+            default:
+                return NULL;
+            }
+
+            if (p == NULL)
+                return NULL;
+        }
+    }
+
+    return p;
+}
+
+/*
+ * Pack integer value (uint32) to provided buffer.
+ * Packing structure:
+ *     uint16 type  (PAT_INT = 3)
+ *     uint16 size  (4)
+ *     uint32 value
+ */
+volatile __uncached char *
+_hl_pack_int(volatile __uncached char *p, uint32_t x)
+{
+    volatile __uncached uint16_t *type = (volatile __uncached uint16_t *)p;
+    volatile __uncached uint16_t *size = (volatile __uncached uint16_t *)(p + 2);
+    volatile __uncached uint32_t *val = (volatile __uncached uint32_t *)(p + 4);
+    const uint32_t                payload_used = 8;
+
+    if (_hl_payload_left(p) < payload_used)
+        return NULL;
+
+    *type = PAT_INT;
+    *size = 4;
+    *val = x;
+
+    return p + payload_used;
+}
+
+/*
+ * Pack data (pointer and length) to provided buffer.
+ * Packing structure:
+ *     uint16 type  (PAT_STRING = 4)
+ *     uint16 size  (length)
+ *     char   buf[length]
+ */
+volatile __uncached char *
+_hl_pack_ptr(volatile __uncached char *p, const void *s, uint16_t len)
+{
+    volatile __uncached uint16_t *type = (volatile __uncached uint16_t *)p;
+    volatile __uncached uint16_t *size = (volatile __uncached uint16_t *)(p + 2);
+    volatile __uncached char     *buf = p + 4;
+    const uint32_t                payload_used = 4 + ALIGN(len, 4);
+
+    if (_hl_payload_left(p) < payload_used)
+        return NULL;
+
+    *type = PAT_STRING;
+    *size = len;
+
+    /* _vdmemcpy(buf, s, len); */
+    for (uint16_t i = 0; i < len; i++)
+        buf[i] = ((const char *)s)[i];
+
+    return p + payload_used;
+}
+
+/*
+ * Pack NUL-terminated string to provided buffer.
+ * Packing structure:
+ *     uint16 type  (PAT_STRING = 4)
+ *     uint16 size  (length)
+ *     char   buf[length]
+ */
+volatile __uncached char *
+_hl_pack_str(volatile __uncached char *p, const char *s)
+{
+    return _hl_pack_ptr(p, s, strlen(s) + 1);
+}
+
+/* Unpack integer value (uint32_t) from a buffer. */
+volatile __uncached char *
+_hl_unpack_int(volatile __uncached char *p, uint32_t *x)
+{
+    volatile __uncached uint16_t *type = (volatile __uncached uint16_t *)p;
+    volatile __uncached uint16_t *size = (volatile __uncached uint16_t *)(p + 2);
+    volatile __uncached uint32_t *val = (volatile __uncached uint32_t *)(p + 4);
+    const uint32_t                payload_used = 8;
+
+    if (_hl_payload_left(p) < payload_used || *type != PAT_INT || *size != 4)
+        return NULL;
+
+    if (x)
+        *x = *val;
+
+    return p + payload_used;
+}
+
+/* Unpack data from a buffer. */
+volatile __uncached char *
+_hl_unpack_ptr(volatile __uncached char *p, void *s, uint32_t *plen)
+{
+    volatile __uncached uint16_t *type = (volatile __uncached uint16_t *)p;
+    volatile __uncached uint16_t *size = (volatile __uncached uint16_t *)(p + 2);
+    volatile __uncached char     *buf = p + 4;
+    uint32_t                      payload_used;
+    uint32_t                      len;
+
+    if (_hl_payload_left(p) < 4 || *type != PAT_STRING)
+        return NULL;
+
+    len = *size;
+    payload_used = 4 + ALIGN(len, 4);
+
+    if (_hl_payload_left(p) < payload_used)
+        return NULL;
+
+    if (plen)
+        *plen = len;
+
+    /* _vsmemcpy(s, buf, len); */
+    if (s) {
+        for (uint32_t i = 0; i < len; i++)
+            ((char *)s)[i] = buf[i];
+    }
+
+    return p + payload_used;
+}
+
+/*
+ * Unpack data from a buffer.
+ *
+ * No difference compared to _hl_unpack_ptr, except that this function
+ * does not return a length.
+ */
+volatile __uncached char *
+_hl_unpack_str(volatile __uncached char *p, char *s)
+{
+    return _hl_unpack_ptr(p, s, NULL);
+}
+
+/* Return length of packed data (PAT_STRING) if it is on top of the buffer. */
+uint32_t
+_hl_get_ptr_len(volatile __uncached char *p)
+{
+    volatile __uncached uint16_t *type = (volatile __uncached uint16_t *)p;
+    volatile __uncached uint16_t *size = (volatile __uncached uint16_t *)(p + 2);
+
+    if (_hl_payload_left(p) < 4 || *type != PAT_STRING)
+        return 0;
+
+    return *size;
+}
+
+/* Public version of _hl_message_va(). */
+volatile __uncached char *
+_hl_message(uint32_t syscall, const char *format, ...)
+{
+    va_list                   ap;
+    volatile __uncached char *p;
+
+    va_start(ap, format);
+
+    p = _hl_message_va(syscall, 0, format, ap);
+
+    va_end(ap);
+
+    return p;
+}
+
+/*
+ * API to call user-defined hostlink. See description of user argument in
+ * _hl_message_va().
+ */
+uint32_t
+_user_hostlink(uint32_t vendor, uint32_t opcode, const char *format, ...)
+{
+    va_list              ap;
+    struct _hl_user_info ui = { .vendor_id = vendor, .opcode = opcode };
+
+    va_start(ap, format);
+
+    _hl_message_va(HL_SYSCALL_USER, &ui, format, ap);
+
+    va_end(ap);
+
+    return ui.result;
+}

--- a/platforms/arc/hl_api.h
+++ b/platforms/arc/hl_api.h
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include "hl_toolchain.h"
+
+#ifndef _HL_API_H
+#define _HL_API_H
+
+#define HL_SYSCALL_OPEN        0
+#define HL_SYSCALL_CLOSE       1
+#define HL_SYSCALL_READ        2
+#define HL_SYSCALL_WRITE       3
+#define HL_SYSCALL_LSEEK       4
+#define HL_SYSCALL_UNLINK      5
+#define HL_SYSCALL_ISATTY      6
+#define HL_SYSCALL_TMPNAM      7
+#define HL_SYSCALL_GETENV      8
+#define HL_SYSCALL_CLOCK       9
+#define HL_SYSCALL_TIME        10
+#define HL_SYSCALL_RENAME      11
+#define HL_SYSCALL_ARGC        12
+#define HL_SYSCALL_ARGV        13
+#define HL_SYSCALL_RETCODE     14
+#define HL_SYSCALL_ACCESS      15
+#define HL_SYSCALL_GETPID      16
+#define HL_SYSCALL_GETCWD      17
+#define HL_SYSCALL_USER        18
+
+#define HL_GNUIO_EXT_VENDOR_ID 1025
+
+#define HL_GNUIO_EXT_FSTAT     1
+
+/*
+ * Main functions to work with regular syscalls and user-defined hostlink
+ * messages.
+ */
+volatile __uncached char *_hl_message(uint32_t syscall, const char *format, ...);
+uint32_t                  _user_hostlink(uint32_t vendor, uint32_t opcode, const char *format, ...);
+
+/* Fuctions for direct work with the Hostlink buffer. */
+volatile __uncached char *_hl_pack_int(volatile __uncached char *p, uint32_t x);
+volatile __uncached char *_hl_pack_ptr(volatile __uncached char *p, const void *s, uint16_t len);
+volatile __uncached char *_hl_pack_str(volatile __uncached char *p, const char *s);
+volatile __uncached char *_hl_unpack_int(volatile __uncached char *p, uint32_t *x);
+volatile __uncached char *_hl_unpack_ptr(volatile __uncached char *p, void *s, uint32_t *plen);
+volatile __uncached char *_hl_unpack_str(volatile __uncached char *p, char *s);
+uint32_t                  _hl_get_ptr_len(volatile __uncached char *p);
+
+/* Low-level functions from hl_gw. */
+extern uint32_t           _hl_iochunk_size(void);
+extern void               _hl_delete(void);
+int                       get_cmdline(char *buffer, int count);
+
+#endif

--- a/platforms/arc/hl_close.c
+++ b/platforms/arc/hl_close.c
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/cdefs.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+int
+close(int fd)
+{
+    int32_t                   ret;
+    uint32_t                  host_errno;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_CLOSE, "i:ii", (uint32_t)fd, (uint32_t *)&ret,
+                    (uint32_t *)&host_errno);
+
+    _hl_delete();
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        ret = -1;
+    } else if (ret < 0) {
+        errno = host_errno;
+        ret = -1;
+    }
+
+    return ret;
+}

--- a/platforms/arc/hl_exit.c
+++ b/platforms/arc/hl_exit.c
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <unistd.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+static void __naked __noreturn
+_hl_halt(int code)
+{
+    /**
+     * Return code is stored in r0 before halt. Place
+     * it to r0 explicitly to suppress a GCC warning.
+     */
+    __asm__("mov r0, %0" : : "r"(code));
+    __asm__("flag 1");
+}
+
+void __noreturn
+_exit(int code)
+{
+    /* Push a return code to host */
+    _hl_message(HL_SYSCALL_RETCODE, "i", (uint32_t)code);
+    _hl_delete();
+    _hl_halt(code);
+}

--- a/platforms/arc/hl_fstat.c
+++ b/platforms/arc/hl_fstat.c
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+/* Hostlink IO version of struct stat. */
+struct hl_stat {
+    uint32_t hl_dev;    /* ID of device containing file. */
+    uint16_t hl_ino;    /* inode number. */
+    uint16_t hl_mode;   /* File type and access mode. */
+    int16_t  hl_nlink;  /* Number of hard links. */
+    int16_t  hl_uid;    /* Owner's UID. */
+    int16_t  hl_gid;    /* Owner's GID. */
+    uint8_t  hl_pad[2]; /* Padding to match simulator struct. */
+    uint32_t hl_rdev;   /* Device ID (if special file). */
+    int32_t  hl_size;   /* Size in bytes. */
+    int32_t  hl_atime;  /* Access time. */
+    int32_t  hl_mtime;  /* Modification time. */
+    int32_t  hl_ctime;  /* Creation time. */
+} __packed;
+
+int
+fstat(int fd, struct stat *statbuf)
+{
+    struct hl_stat hl_statbuf;
+    int32_t        ret;
+    uint32_t       host_errno;
+
+    /* Special version of hostlink - returned values are passed
+     * through inargs.
+     */
+    host_errno = _user_hostlink(HL_GNUIO_EXT_VENDOR_ID, HL_GNUIO_EXT_FSTAT, "iii", (uint32_t)fd,
+                                (uint32_t)&hl_statbuf, (uint32_t)&ret);
+
+    _hl_delete();
+
+    if (ret < 0) {
+        errno = host_errno;
+        return ret;
+    }
+
+    statbuf->st_dev = hl_statbuf.hl_dev;
+    statbuf->st_ino = hl_statbuf.hl_ino;
+    statbuf->st_mode = hl_statbuf.hl_mode;
+    statbuf->st_nlink = hl_statbuf.hl_nlink;
+    statbuf->st_uid = hl_statbuf.hl_uid;
+    statbuf->st_gid = hl_statbuf.hl_gid;
+    statbuf->st_rdev = hl_statbuf.hl_rdev;
+    statbuf->st_size = hl_statbuf.hl_size;
+    statbuf->st_atime = hl_statbuf.hl_atime;
+    statbuf->st_mtime = hl_statbuf.hl_mtime;
+    statbuf->st_ctime = hl_statbuf.hl_ctime;
+
+    return ret;
+}

--- a/platforms/arc/hl_get_cmdline.c
+++ b/platforms/arc/hl_get_cmdline.c
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include <stddef.h>
+#include <sys/cdefs.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+static __always_inline int
+_hl_argc(void)
+{
+    uint32_t                  ret;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_ARGC, ":i", (uint32_t *)&ret);
+    _hl_delete();
+
+    if (p == NULL)
+        ret = 0;
+
+    return ret;
+}
+
+static __always_inline int
+_hl_argv(int a, char *arg)
+{
+    int                       ret = 0;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_ARGV, "i:s", (uint32_t)a, (char *)arg);
+    _hl_delete();
+
+    if (p == NULL)
+        ret = -1;
+
+    return ret;
+}
+
+/* Get buffer length for argv[a] using HL_SYSCALL_ARGV */
+static __always_inline uint32_t
+_hl_argv_len(int a)
+{
+    uint32_t                  ret = 0;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_ARGV, "i", (uint32_t)a);
+
+    if (p != NULL)
+        ret = _hl_get_ptr_len(p);
+
+    _hl_delete();
+
+    return ret;
+}
+
+int
+get_cmdline(char *buffer, int count)
+{
+    int      argc;
+    uint32_t argv_len;
+    int      i;
+
+    argc = _hl_argc();
+
+    if (argc == 0)
+        return -1;
+
+    for (i = 0; i < argc; i++) {
+        /* This variables store's argument's length including \0 */
+        argv_len = _hl_argv_len(i);
+
+        /* Stop processing arguments when the limit is exceeded */
+        count -= argv_len;
+        if (count < 0)
+            break;
+
+        if (i != 0) {
+            buffer[0] = ' ';
+            buffer += 1;
+        }
+
+        if (_hl_argv(i, buffer) < 0)
+            return -1;
+
+        buffer += argv_len - 1;
+    }
+
+    return 0;
+}

--- a/platforms/arc/hl_gettimeofday.c
+++ b/platforms/arc/hl_gettimeofday.c
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+int
+gettimeofday(struct timeval * restrict tv, void * restrict tz)
+{
+    int                       ret;
+    uint32_t                  host_timer;
+    volatile __uncached char *p;
+
+    (void)tz;
+
+    p = _hl_message(HL_SYSCALL_TIME, ":i", (uint32_t *)&host_timer);
+    _hl_delete();
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        ret = -1;
+    } else
+        ret = 0;
+
+    if (ret == 0) {
+        tv->tv_sec = (time_t)host_timer;
+        tv->tv_usec = 0;
+    }
+
+    return ret;
+}

--- a/platforms/arc/hl_gw.c
+++ b/platforms/arc/hl_gw.c
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Hostlink gateway, low-level hostlink functions. */
+
+#include <stdint.h>
+#include <sys/cdefs.h>
+#include "hl_gw.h"
+
+#define HL_VERSION 1
+
+/*
+ * Maximum message size without service information,
+ * see also HL_PAYLOAD_RESERVED.
+ */
+#ifndef HL_IOCHUNK
+#define HL_IOCHUNK 1024
+#endif
+
+/*
+ * Each syscall argument have 4 bytes of service information in hostlink
+ * protocol (2 bytes for type and 2 for size).  Here we reserve space for
+ * 32 arguments.
+ */
+#define HL_PAYLOAD_RESERVED (32 * 4)
+
+/* "No message here" mark. */
+#define HL_NOADDRESS 0xFFFFFFFF
+
+/* Hostlink gateway structure. */
+struct _hl_hdr {
+    uint32_t version;           /* Current version is 1. */
+    uint32_t target2host_addr;  /* Packet address from target to host. */
+    uint32_t host2target_addr;  /* Packet address from host to target. */
+    uint32_t buf_addr;          /* Address for host to write answer. */
+    uint32_t payload_size;      /* Buffer size without packet header. */
+    uint32_t options;           /* For future use. */
+    uint32_t break_to_mon_addr; /* For future use. */
+} __uncached __packed;
+
+/* Hostlink packet header. */
+struct _hl_pkt_hdr {
+    uint32_t packet_id;  /* Packet id.  Always set to 1 here. */
+    uint32_t total_size; /* Size of packet including header. */
+    uint32_t priority;   /* For future use. */
+    uint32_t type;       /* For future use. */
+    uint32_t checksum;   /* For future use. */
+} __uncached __packed;
+
+/* Main hostlink structure. */
+struct _hl {
+    volatile struct _hl_hdr     hdr; /* General hostlink information. */
+    /* Start of the hostlink buffer. */
+    volatile struct _hl_pkt_hdr pkt_hdr;
+    volatile char               payload[HL_IOCHUNK + HL_PAYLOAD_RESERVED];
+} __aligned(HL_MAX_DCACHE_LINE) __uncached __packed;
+
+/*
+ * Main structure.  Do not rename because simulator will look for the
+ * '__HOSTLINK__' symbol.
+ */
+volatile struct _hl             __HOSTLINK__ = {
+    .hdr = { .version = 1, .target2host_addr = HL_NOADDRESS }
+};
+
+/* Get hostlink payload pointer. */
+volatile __uncached void *
+_hl_payload(void)
+{
+    return (volatile __uncached void *)&__HOSTLINK__.payload[0];
+}
+
+/* Get hostlink payload size (iochunk + reserved space). */
+static uint32_t
+_hl_payload_size(void)
+{
+    return sizeof(__HOSTLINK__.payload);
+}
+
+/* Get used space size in the payload. */
+static uint32_t
+_hl_payload_used(volatile __uncached void *p)
+{
+    return (volatile __uncached char *)p - (volatile __uncached char *)_hl_payload();
+}
+
+/* Fill hostlink packet header. */
+static void
+_hl_pkt_init(volatile __uncached struct _hl_pkt_hdr *pkt, int size)
+{
+    pkt->packet_id = 1;
+    pkt->total_size = ALIGN(size, 4) + sizeof(*pkt);
+    pkt->priority = 0;
+    pkt->type = 0;
+    pkt->checksum = 0;
+}
+
+/* Get hostlink iochunk size. */
+uint32_t
+_hl_iochunk_size(void)
+{
+    return HL_IOCHUNK;
+}
+
+/* Get free space size in the payload. */
+uint32_t
+_hl_payload_left(volatile __uncached void *p)
+{
+    return _hl_payload_size() - _hl_payload_used(p);
+}
+
+/* Send hostlink packet to the host. */
+void
+_hl_send(volatile __uncached void *p)
+{
+    volatile __uncached struct _hl_hdr     *hdr = &__HOSTLINK__.hdr;
+    volatile __uncached struct _hl_pkt_hdr *pkt_hdr = &__HOSTLINK__.pkt_hdr;
+
+    _hl_pkt_init(pkt_hdr, _hl_payload_used(p));
+
+#if defined(__ARC64__)
+    /*
+     * Here we pass only low 4 bytes of the packet address (pkt_hdr).
+     * The high part of the address is obtained from __HOSTLINK__ address.
+     */
+    hdr->buf_addr = (uintptr_t)pkt_hdr & 0xFFFFFFFF;
+#else
+    hdr->buf_addr = (uint32_t)pkt_hdr;
+#endif
+    hdr->payload_size = _hl_payload_size();
+    hdr->host2target_addr = HL_NOADDRESS;
+    hdr->version = HL_VERSION;
+    hdr->options = 0;
+    hdr->break_to_mon_addr = 0;
+
+    /* This tells the debugger we have a command.
+     * It is responsibility of debugger to set this back to HL_NOADDRESS
+     * after receiving the packet.
+     * Please note that we don't wait here because some implementations
+     * use _hl_blockedPeek() function as a signal that we send a message.
+     */
+    hdr->target2host_addr = hdr->buf_addr;
+}
+
+/*
+ * Wait for host response and return pointer to hostlink payload.
+ * Symbol _hl_blockedPeek() is used by the simulator as message signal.
+ */
+volatile __uncached char * __noinline
+_hl_blockedPeek(void)
+{
+    while (__HOSTLINK__.hdr.host2target_addr == HL_NOADDRESS) {
+        /* TODO: Timeout. */
+    }
+
+    return _hl_payload();
+}
+
+/* Get message from host. */
+volatile __uncached char *
+_hl_recv(void)
+{
+    return _hl_blockedPeek();
+}
+
+/* Mark hostlink buffer as "No message here". */
+void
+_hl_delete(void)
+{
+    __HOSTLINK__.hdr.target2host_addr = HL_NOADDRESS;
+}

--- a/platforms/arc/hl_gw.h
+++ b/platforms/arc/hl_gw.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _HL_GW_H
+#define _HL_GW_H
+
+#include <stdint.h>
+
+#include "hl_toolchain.h"
+
+/* Get hostlink payload pointer and size available for using. */
+volatile __uncached void             *_hl_payload(void);
+
+/* Maximum amount of data that can be sent via hostlink in one message. */
+uint32_t                              _hl_iochunk_size(void);
+
+/*
+ * How many bytes are available in the hostlink payload buffer.
+ * This may be bigger than iochunk size because hostlink payload also contains
+ * reserved space for service information.
+ */
+uint32_t                              _hl_payload_left(volatile __uncached void *p);
+
+/* Send and receive hostlink packet. */
+void                                  _hl_send(volatile __uncached void *p);
+volatile __uncached char * __noinline _hl_blockedPeek(void);
+volatile __uncached char             *_hl_recv(void);
+
+/* Mark target2host buffer as "No message here". */
+void                                  _hl_delete(void);
+
+#endif

--- a/platforms/arc/hl_isatty.c
+++ b/platforms/arc/hl_isatty.c
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+int
+isatty(int fd)
+{
+    int32_t                   ret;
+    uint32_t                  host_errno;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_ISATTY, "i:ii", (uint32_t)fd, (uint32_t *)&ret,
+                    (uint32_t *)&host_errno);
+    _hl_delete();
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        ret = 0;
+    } else if (ret == 0)
+        errno = host_errno;
+    else
+        ret = 1;
+
+    return ret;
+}

--- a/platforms/arc/hl_kill.c
+++ b/platforms/arc/hl_kill.c
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include <sys/types.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+
+pid_t
+getpid(void)
+{
+    return 1;
+}
+
+int
+kill(pid_t pid, int sig)
+{
+    if (pid == 1)
+        _exit(128 + sig);
+    errno = ESRCH;
+    return -1;
+}

--- a/platforms/arc/hl_lseek.c
+++ b/platforms/arc/hl_lseek.c
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+off_t
+lseek(int fd, off_t offset, int whence)
+{
+    ssize_t                   ret;
+    int32_t                   n;
+    uint32_t                  host_errno;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_LSEEK, "iii:ii", (uint32_t)fd, (uint32_t)offset, (int32_t)whence,
+                    (uint32_t *)&n, (uint32_t *)&host_errno);
+    _hl_delete();
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        ret = -1;
+    } else if (n < 0) {
+        errno = host_errno;
+        ret = -1;
+    } else
+        ret = n;
+
+    return ret;
+}

--- a/platforms/arc/hl_open.c
+++ b/platforms/arc/hl_open.c
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+int
+open(const char *pathname, int flags, ...)
+{
+    va_list                   ap;
+    mode_t                    mode = 0;
+    int32_t                   fd;
+    uint32_t                  host_errno;
+    uint32_t                  hl_flags = 0;
+    volatile __uncached char *p;
+
+    va_start(ap, flags);
+    if (flags & O_CREAT)
+        mode = va_arg(ap, mode_t);
+    va_end(ap);
+
+    hl_flags |= (flags & O_RDONLY) ? 0x0000 : 0;
+    hl_flags |= (flags & O_WRONLY) ? 0x0001 : 0;
+    hl_flags |= (flags & O_RDWR) ? 0x0002 : 0;
+    hl_flags |= (flags & O_APPEND) ? 0x0008 : 0;
+    hl_flags |= (flags & O_CREAT) ? 0x0100 : 0;
+    hl_flags |= (flags & O_TRUNC) ? 0x0200 : 0;
+    hl_flags |= (flags & O_EXCL) ? 0x0400 : 0;
+
+    p = _hl_message(HL_SYSCALL_OPEN, "sii:ii", pathname, (uint32_t)hl_flags, (uint32_t)mode,
+                    (uint32_t *)&fd, (uint32_t *)&host_errno);
+    _hl_delete();
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        fd = -1;
+    } else if (fd < 0) {
+        errno = host_errno;
+        fd = -1;
+    }
+
+    return fd;
+}

--- a/platforms/arc/hl_read.c
+++ b/platforms/arc/hl_read.c
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <unistd.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+static ssize_t
+_hl_read(int fd, void *buf, size_t count)
+{
+    ssize_t                   ret;
+    int32_t                   hl_n;
+    uint32_t                  host_errno;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_READ, "ii:i", (uint32_t)fd, (uint32_t)count, (uint32_t *)&hl_n);
+    _hl_delete();
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        ret = -1;
+    } else if (hl_n < 0) {
+        p = _hl_unpack_int(p, &host_errno);
+        errno = p == NULL ? EIO : host_errno;
+        ret = -1;
+    } else {
+        uint32_t n;
+
+        p = _hl_unpack_ptr(p, buf, &n);
+        ret = n;
+
+        if (p == NULL || n != (uint32_t)hl_n) {
+            errno = EIO;
+            ret = -1;
+        }
+    }
+
+    return ret;
+}
+
+ssize_t
+read(int fd, void *buf, size_t count)
+{
+    const uint32_t hl_iochunk = _hl_iochunk_size();
+    size_t         to_read = count;
+    size_t         offset = 0;
+    ssize_t        ret = 0;
+
+    while (to_read > hl_iochunk) {
+        ret = _hl_read(fd, (char *)buf + offset, hl_iochunk);
+
+        if (ret < 0)
+            return ret;
+
+        offset += ret;
+
+        if (ret != (ssize_t)hl_iochunk)
+            return offset;
+
+        to_read -= hl_iochunk;
+    }
+
+    if (to_read) {
+        ret = _hl_read(fd, (char *)buf + offset, to_read);
+
+        if (ret < 0)
+            return ret;
+
+        ret += offset;
+    }
+
+    return ret;
+}

--- a/platforms/arc/hl_times.c
+++ b/platforms/arc/hl_times.c
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/times.h>
+#include <sys/time.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+clock_t
+times(struct tms *buf)
+{
+    clock_t                   ret;
+    volatile __uncached char *p;
+
+    if (buf == NULL) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    p = _hl_message(HL_SYSCALL_CLOCK, ":i", (uint32_t *)&ret);
+    _hl_delete();
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        return -1;
+    }
+
+    if (ret == (clock_t)-1)
+        return ret;
+
+    buf->tms_utime = ret;
+    buf->tms_stime = 0;
+    buf->tms_cutime = 0;
+    buf->tms_cstime = 0;
+
+    return ret;
+}

--- a/platforms/arc/hl_toolchain.h
+++ b/platforms/arc/hl_toolchain.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _HL_TOOLCHAIN_H
+#define _HL_TOOLCHAIN_H
+
+#ifndef __uncached
+#if defined(__ARC64__)
+/* TODO: Uncached attribute is not implemented for ARCv3 yet. */
+#define __uncached
+#else
+#define __uncached __attribute__((uncached))
+#endif
+#endif /* __uncached */
+
+#ifndef __longcall
+#if defined(__ARC64__)
+/* TODO: Long call attribute is not implemented for ARCv3 yet. */
+#define __longcall
+#else
+#define __longcall __attribute__((long_call))
+#endif
+#endif /* __longcall */
+
+#define HL_MAX_DCACHE_LINE 256
+
+#define ALIGN(x, y)        (((x) + ((y) - 1)) & ~((y) - 1))
+
+#endif

--- a/platforms/arc/hl_unlink.c
+++ b/platforms/arc/hl_unlink.c
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+int
+unlink(const char *pathname)
+{
+    int32_t                   ret;
+    uint32_t                  host_errno;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_UNLINK, "s:ii", pathname, (uint32_t *)&ret, (uint32_t *)&host_errno);
+    _hl_delete();
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        ret = -1;
+    } else if (ret < 0) {
+        errno = host_errno;
+        ret = -1;
+    }
+
+    return ret;
+}

--- a/platforms/arc/hl_write.c
+++ b/platforms/arc/hl_write.c
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <unistd.h>
+
+#include "hl_toolchain.h"
+#include "hl_api.h"
+
+static ssize_t
+_hl_write(int fd, const char *buf, size_t nbyte)
+{
+    ssize_t                   ret;
+    int32_t                   n;
+    uint32_t                  host_errno;
+    volatile __uncached char *p;
+
+    p = _hl_message(HL_SYSCALL_WRITE, "ipi:ii", (uint32_t)fd, buf, (uint32_t)nbyte, (uint32_t)nbyte,
+                    (uint32_t *)&n, (uint32_t *)&host_errno);
+
+    if (p == NULL) {
+        errno = ETIMEDOUT;
+        ret = -1;
+    } else if (n < 0) {
+        errno = host_errno;
+        ret = -1;
+    } else {
+        ret = n;
+    }
+
+    _hl_delete();
+
+    return ret;
+}
+
+ssize_t
+write(int fd, const void *buf, size_t count)
+{
+    const uint32_t hl_iochunk = _hl_iochunk_size();
+    size_t         to_write = count;
+    size_t         offset = 0;
+    ssize_t        ret = 0;
+
+    while (to_write > hl_iochunk) {
+        ret = _hl_write(fd, (char *)buf + offset, hl_iochunk);
+
+        if (ret < 0)
+            return ret;
+
+        offset += ret;
+
+        if (ret != (ssize_t)hl_iochunk)
+            return offset;
+
+        to_write -= hl_iochunk;
+    }
+
+    if (to_write) {
+        ret = _hl_write(fd, (char *)buf + offset, to_write);
+
+        if (ret < 0)
+            return ret;
+
+        ret += offset;
+    }
+
+    return ret;
+}

--- a/platforms/arc64/meson.build
+++ b/platforms/arc64/meson.build
@@ -34,75 +34,30 @@
 #
 
 src_hl = files([
-                'hl_api.c',
-                'hl_close.c',
-                'hl_exit.c',
-                'hl_fstat.c',
-                'hl_get_cmdline.c',
-                'hl_gettimeofday.c',
-                'hl_gw.c',
-                'hl_isatty.c',
-                'hl_kill.c',
-                'hl_lseek.c',
-                'hl_open.c',
-                'hl_read.c',
-                'hl_times.c',
-                'hl_unlink.c',
-                'hl_write.c',
+                '../arc/hl_api.c',
+                '../arc/hl_close.c',
+                '../arc/hl_exit.c',
+                '../arc/hl_get_cmdline.c',
+                '../arc/hl_gettimeofday.c',
+                '../arc/hl_gw.c',
+                '../arc/hl_isatty.c',
+                '../arc/hl_kill.c',
+                '../arc/hl_lseek.c',
+                '../arc/hl_open.c',
+                '../arc/hl_read.c',
+                '../arc/hl_times.c',
+                '../arc/hl_unlink.c',
+                '../arc/hl_write.c',
                ])
-
-src_uart_8250 = [
-                 'uart_8250_exit.c',
-                 'uart_8250_kill.c',
-                 'uart_8250_stub.c',
-                 'uart_8250.c',
-                ]
-
-src_hsdk = files(['hsdk.c'] + src_uart_8250)
-src_emsdp = files(['emsdp.c'] + src_uart_8250)
 
 foreach params : targets
   target = params['name']
   target_dir = params['dir']
   target_c_args = params['c_args']
-  src_platform = []
-
-  is_arcem = '''
-  #ifndef __ARCEM__
-  #error __ARCEM__ is not defined
-  #endif
-  '''
-
-  if cc.compiles(is_arcem, args: target_c_args + c_args)
-    platform_name = 'emsdp'
-    src_platform = src_emsdp
-  endif
-
-  is_archs = '''
-  #ifndef __ARCHS__
-  #error __ARCHS__ is not defined
-  #endif
-  '''
-
-  if cc.compiles(is_archs, args: target_c_args + c_args)
-    platform_name = 'hsdk'
-    src_platform = src_hsdk
-  endif
-
-  if src_platform == []
-    continue
-  endif
 
   instdir = join_paths(lib_dir, target_dir)
 
   if meson.version().version_compare('>=1.10')
-    _lib = static_library(platform_name,
-                          src_platform,
-                          build_subdir : target_dir,
-                          install : really_install,
-                          install_dir : instdir,
-                          include_directories : inc,
-                          c_args : target_c_args + c_args)
     _lib = static_library('hl',
                           src_hl,
                           build_subdir : target_dir,
@@ -112,23 +67,11 @@ foreach params : targets
                           c_args : target_c_args + c_args)
   else
     target_lib_prefix = params['lib_prefix']
-    _lib = static_library(join_paths(target_dir, target_lib_prefix + platform_name),
-                          src_platform,
-                          install : really_install,
-                          install_dir : instdir,
-                          include_directories : inc,
-                          c_args : target_c_args + c_args)
     _lib = static_library(join_paths(target_dir, target_lib_prefix + 'hl'),
                           src_hl,
                           install : really_install,
                           install_dir : instdir,
                           include_directories : inc,
                           c_args : target_c_args + c_args)
-  endif
-endforeach
-
-foreach specs_file : ['hsdk.specs', 'emsdp1.1.specs', 'emsdp1.2.specs']
-  if specs_install and really_install
-    install_data(specs_file, install_dir: specs_dir)
   endif
 endforeach

--- a/scripts/cross-arc-snps-elf.txt
+++ b/scripts/cross-arc-snps-elf.txt
@@ -1,6 +1,6 @@
 [binaries]
-c = ['arc-snps-elf-gcc', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
-cpp = ['arc-snps-elf-g++', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
+c = ['arc-snps-elf-gcc', '-nostdlib', '-fno-delayed-branch']
+cpp = ['arc-snps-elf-g++', '-nostdlib', '-fno-delayed-branch']
 ar = 'arc-snps-elf-ar'
 as = 'arc-snps-elf-as'
 nm = 'arc-snps-elf-nm'


### PR DESCRIPTION
Hostlink is I/O interface in Synopsys nSIM simulator which works without interrupts, supports more system calls than semihosting interface and supports passing command line arguments.

Hostlink in Picolibc is not going to be upstreamed. It will be used only for testing and for compatibility with Newlib for ARC Classic.

Use `--oslib=hl --crt0=hl` to link with Hostlink.

Note that `fstat` call is excluded for ARCv3 64-bit targets because the original implementation from Newlib is incorrect for 64-bit targets.

Also, this PR fixes SDA relocation overflows by putting `__SDATA_BEGIN__` to the right place.